### PR TITLE
fix: preserve timezone selection in ScheduleCard

### DIFF
--- a/components/ScheduleCard.tsx
+++ b/components/ScheduleCard.tsx
@@ -136,7 +136,13 @@ export default function ScheduleCard({
     setEndTime(itinerary.end_time || '')
     setTempStartTime(itinerary.start_time || '')
     setTempEndTime(itinerary.end_time || '')
-    setDestinationTimezone('UTC')
+    
+    // タイムゾーンは既存の値を保持し、なければUTCをデフォルトに
+    if (itinerary.timezone) {
+      setDestinationTimezone(itinerary.timezone)
+    } else {
+      setDestinationTimezone('UTC')
+    }
     
     // 説明欄の初期値を設定（editorial_summaryがあれば使用、なければ既存のdescription）
     if (itinerary.place_data?.editorial_summary?.overview && !itinerary.description) {
@@ -144,7 +150,7 @@ export default function ScheduleCard({
     } else {
       setDescription(itinerary.description || '')
     }
-  }, [itinerary.id, itinerary.title, itinerary.start_time, itinerary.end_time, itinerary.description, itinerary.place_data?.editorial_summary?.overview]) // itinerary.idを追加してオブジェクト参照の変更に対応
+  }, [itinerary.id, itinerary.title, itinerary.start_time, itinerary.end_time, itinerary.description, itinerary.place_data?.editorial_summary?.overview, itinerary.timezone]) // itinerary.timezoneを追加
 
   // ブラウザのタイムゾーンを取得
   useEffect(() => {
@@ -157,8 +163,8 @@ export default function ScheduleCard({
       const detectedTimezone = timezoneUtils.getTimezoneFromPlace(itinerary.place_data)
       if (detectedTimezone !== 'UTC') {
         setDestinationTimezone(detectedTimezone)
-        // タイムゾーンの保存は手動で行う（自動保存を無効化）
-        // handleTimezoneUpdate(detectedTimezone)
+        // タイムゾーンを自動保存
+        handleTimezoneUpdate(detectedTimezone)
       }
     }
   }, [itinerary.place_data?.place_id]) // place_idを使用して無限ループを防ぐ
@@ -738,7 +744,10 @@ export default function ScheduleCard({
                       <label className="text-sm font-medium text-gray-700">タイムゾーン:</label>
                       <select
                         value={destinationTimezone}
-                        onChange={(e) => setDestinationTimezone(e.target.value)}
+                        onChange={(e) => {
+                          setDestinationTimezone(e.target.value)
+                          handleTimezoneUpdate(e.target.value)
+                        }}
                         className="px-2 py-1 border border-gray-300 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                       >
                         <option value="UTC">UTC</option>

--- a/lib/plan-save-operations.ts
+++ b/lib/plan-save-operations.ts
@@ -308,6 +308,7 @@ export class PlanSaveOperations {
       place_data: itineraryData.place_data,
       start_time: itineraryData.start_time,
       end_time: itineraryData.end_time,
+      timezone: itineraryData.timezone,
       cost_amount: itineraryData.cost_amount,
       cost_currency: itineraryData.cost_currency,
       created_at: new Date(),

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -78,6 +78,7 @@ export interface Itinerary {
   place_data?: PlaceData | null
   start_time?: string
   end_time?: string
+  timezone?: string
   cost_amount?: number | null
   cost_currency?: string
   created_at: Date | string
@@ -157,6 +158,7 @@ export interface ItineraryFormData {
   place_data?: PlaceData | null
   start_time?: string
   end_time?: string
+  timezone?: string
   cost_amount?: number | null
   cost_currency?: string
 }


### PR DESCRIPTION
- Remove forced UTC reset on itinerary changes
- Add timezone field to Itinerary and ItineraryFormData interfaces
- Update plan-save-operations to save timezone information
- Enable automatic timezone saving when detected from place data

Fixes issue where timezone would reset from Asia/Tokyo to UTC

 ## 🐛 Bug Fix: Timezone Reset Issue
   
   ### Problem
   タイムゾーンがAsia/TokyoからUTCに戻ってしまう問題が発生していました。
   
   ### Root Cause
   - `ScheduleCard.tsx`でitineraryの変更時にタイムゾーンが強制的にUTCにリセット
   - `Itinerary`インターフェースにtimezoneフィールドが存在しない
   - タイムゾーン情報が保存されていない
   
   ### Solution
   - ✅ ScheduleCardでタイムゾーンを保持するように修正
   - ✅ Itineraryインターフェースにtimezoneフィールドを追加
   - ✅ タイムゾーン情報の保存ロジックを更新
   - ✅ 場所情報からの自動タイムゾーン検出時に自動保存を有効化
   
   ### Files Changed
   - `components/ScheduleCard.tsx`
   - `lib/types.ts`
   - `lib/plan-save-operations.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added inline timezone selection for schedules with automatic saving on change or detection.
  - Editing times now saves start, end, and timezone together for consistency.
  - New itineraries now store timezone, ensuring consistent context across the plan.

- Bug Fixes
  - Preserves existing itinerary timezone instead of defaulting to UTC.
  - Timezone initialization now reacts correctly to updates, keeping the UI in sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->