### PR TITLE
Fix itinerary display order and sort numbers

### DIFF
--- a/app/api/itineraries/insert/route.ts
+++ b/app/api/itineraries/insert/route.ts
@@ -13,7 +13,7 @@ import type { PlaceData } from '@/lib/types'
  *   - `place_data` (optional): partial place payload used to populate cache when the place is not found in PLACES_CACHE
  *   - `description` (optional): itinerary description
  *   - `location` (optional): itinerary location string
- *   - `insert_after_index` (optional): 1-based display index after which to insert; if omitted or out of range, the itinerary is appended
+ *   - `insert_after_index` (optional): sort_number of the itinerary after which to insert (1-based); if omitted or out of range, the itinerary is appended
  * @returns The saved itinerary object containing `id`, the persisted itinerary fields (including `sort_number`), and `place_data` set to the resolved PlaceData or `null`.
  *
  * On validation failure returns a 400 response with an error message. On unexpected errors returns a 500 response.
@@ -46,40 +46,17 @@ export async function POST(request: NextRequest) {
     }))
 
     // 挿入位置に基づいて新しいsort_numberを計算
+    // insertAfterIndexはsort_numberの値（1ベース）として扱う
     let newSortNumber: number
     
     console.log(`Insert API: insertAfterIndex=${insertAfterIndex}, existingItineraries.length=${existingItineraries.length}`)
     console.log(`Existing itineraries sort_numbers:`, existingItineraries.map(i => ({ id: i.id, title: i.title, sort_number: i.sort_number })))
     
-    if (insertAfterIndex < 0 || insertAfterIndex >= existingItineraries.length) {
-      // 最後に追加する場合
-      newSortNumber = existingItineraries.length > 0 
-        ? Math.max(...existingItineraries.map((i: any) => i.sort_number || 0)) + 1 
-        : 1
-    } else {
-      // 指定位置に挿入する場合
-      // insertAfterIndexは表示番号（1ベース）なので、配列インデックス（0ベース）に変換
-      const targetIndex = insertAfterIndex - 1
-      let itinerariesToUpdate: any[] = []
-      
-      if (targetIndex >= 0 && targetIndex < existingItineraries.length) {
-        // 手前のItineraryのsort_number + 1を使用
-        const previousItinerary = existingItineraries[targetIndex]
-        newSortNumber = (previousItinerary.sort_number || 0) + 1
-        
-        console.log(`Insert after index ${insertAfterIndex}: previousItinerary sort_number=${previousItinerary.sort_number}, newSortNumber=${newSortNumber}`)
-        
-        // 後続のitinerariesのsort_numberを1つずつ増やす
-        itinerariesToUpdate = existingItineraries.filter((i: any) => (i.sort_number || 0) >= newSortNumber)
-      } else {
-        // 範囲外の場合は最後に追加
-        newSortNumber = existingItineraries.length > 0 
-          ? Math.max(...existingItineraries.map((i: any) => i.sort_number || 0)) + 1 
-          : 1
-        itinerariesToUpdate = []
-      }
-      
-      // バッチ処理で後続のitinerariesを更新
+    if (insertAfterIndex <= 0) {
+      // 先頭に追加する場合（insertAfterIndex=0または負の値）
+      newSortNumber = 1
+      // 既存の全itinerariesのsort_numberを1つずつ増やす
+      const itinerariesToUpdate = existingItineraries
       const batch = adminDb.batch()
       
       for (const itinerary of itinerariesToUpdate) {
@@ -90,10 +67,46 @@ export async function POST(request: NextRequest) {
         })
       }
       
-      // バッチ更新を実行
       if (itinerariesToUpdate.length > 0) {
         await batch.commit()
-        console.log(`Updated ${itinerariesToUpdate.length} itineraries after insertion`)
+        console.log(`Updated ${itinerariesToUpdate.length} itineraries after insertion at beginning`)
+      }
+    } else {
+      // insertAfterIndexで指定されたsort_numberの後に挿入する
+      // 例: insertAfterIndex=2の場合、sort_number=2の後（つまりsort_number=3の位置）に挿入
+      const targetItinerary = existingItineraries.find((i: any) => i.sort_number === insertAfterIndex)
+      
+      if (!targetItinerary) {
+        // 指定されたsort_numberのitineraryが見つからない場合は最後に追加
+        console.log(`Itinerary with sort_number=${insertAfterIndex} not found, appending to end`)
+        newSortNumber = existingItineraries.length > 0 
+          ? Math.max(...existingItineraries.map((i: any) => i.sort_number || 0)) + 1 
+          : 1
+      } else {
+        // 指定されたsort_numberの次の位置に挿入
+        newSortNumber = insertAfterIndex + 1
+        
+        console.log(`Insert after sort_number ${insertAfterIndex}: newSortNumber=${newSortNumber}`)
+        
+        // 後続のitinerariesのsort_numberを1つずつ増やす
+        const itinerariesToUpdate = existingItineraries.filter((i: any) => (i.sort_number || 0) >= newSortNumber)
+        
+        // バッチ処理で後続のitinerariesを更新
+        const batch = adminDb.batch()
+        
+        for (const itinerary of itinerariesToUpdate) {
+          const docRef = itinerariesRef.doc(itinerary.id)
+          batch.update(docRef, { 
+            sort_number: (itinerary as any).sort_number + 1,
+            updated_at: new Date()
+          })
+        }
+        
+        // バッチ更新を実行
+        if (itinerariesToUpdate.length > 0) {
+          await batch.commit()
+          console.log(`Updated ${itinerariesToUpdate.length} itineraries after insertion`)
+        }
       }
     }
 

--- a/components/modals/AddScheduleModal.tsx
+++ b/components/modals/AddScheduleModal.tsx
@@ -10,7 +10,7 @@ interface AddScheduleModalProps {
   onClose: () => void
   dayId: string
   onScheduleAdded: (schedule: any) => void
-  insertAfterIndex?: number // 挿入位置を指定（undefinedの場合は最後に追加）
+  insertAfterIndex?: number // 挿入位置を指定（sort_numberの値、undefinedの場合は最後に追加）
 }
 
 /**
@@ -24,7 +24,7 @@ interface AddScheduleModalProps {
  * @param onClose - Callback invoked when the modal is closed
  * @param dayId - Identifier of the day to which the schedule will be added
  * @param onScheduleAdded - Callback invoked with the newly created schedule object after a successful save
- * @param insertAfterIndex - Optional zero-based index after which the new schedule should be inserted; undefined means append to the end
+ * @param insertAfterIndex - Optional sort_number (1-based) of the itinerary after which the new schedule should be inserted; undefined means append to the end
  * @returns The modal element when `isOpen` is true, otherwise `null`
  */
 export default function AddScheduleModal({ 

--- a/components/trip/TripItineraryView.tsx
+++ b/components/trip/TripItineraryView.tsx
@@ -188,13 +188,13 @@ export default function TripItineraryView({
                         </div>
                         <DndContext collisionDetection={closestCenter} onDragEnd={onDragEnd}>
                           <SortableContext 
-                            items={day.itineraries.map(i => i.id)} 
+                            items={[...day.itineraries].sort((a, b) => a.sort_number - b.sort_number).map(i => i.id)} 
                             strategy={verticalListSortingStrategy}
                           >
                             <div className="space-y-0">
-                              {day.itineraries.map((itinerary, index) => {
-                                const previousItinerary = index > 0 ? day.itineraries?.[index - 1] : null
-                                const nextItinerary = index < (day.itineraries?.length || 0) - 1 ? day.itineraries?.[index + 1] : null
+                              {[...day.itineraries].sort((a, b) => a.sort_number - b.sort_number).map((itinerary, index, sortedArray) => {
+                                const previousItinerary = index > 0 ? sortedArray[index - 1] : null
+                                const nextItinerary = index < sortedArray.length - 1 ? sortedArray[index + 1] : null
                                 
                                 return (
                                   <div key={itinerary.id} className="relative">
@@ -211,7 +211,7 @@ export default function TripItineraryView({
                                       onItineraryClick={onItineraryClick}
                                       isSelected={selectedItineraryId === itinerary.id}
                                       isFirst={index === 0}
-                                      isLast={index === (day.itineraries?.length || 0) - 1}
+                                      isLast={index === sortedArray.length - 1}
                                       availableDays={trip.days?.map(d => ({
                                         id: d.id,
                                         day_number: d.day_number,
@@ -228,16 +228,16 @@ export default function TripItineraryView({
                                         toPlace={nextItinerary.place_data}
                                         mode="driving"
                                         showInsertButton={true}
-                                        onInsertVenue={() => onInsertSchedule(day.id, index + 1)}
+                                        onInsertVenue={() => onInsertSchedule(day.id, itinerary.sort_number)}
                                       />
                                     )}
                                     
                                     {/* Venue間の挿入ボタン（距離表示がない場合のみ） */}
-                                    {index < (day.itineraries?.length || 0) - 1 && 
+                                    {index < sortedArray.length - 1 && 
                                      (!itinerary.place_data || !nextItinerary?.place_data || 
                                       itinerary.place_data.place_id === nextItinerary.place_data.place_id) && (
                                       <VenueInsertButton
-                                        onInsert={() => onInsertSchedule(day.id, index + 1)}
+                                        onInsert={() => onInsertSchedule(day.id, itinerary.sort_number)}
                                         dayId={day.id}
                                       />
                                     )}
@@ -246,31 +246,35 @@ export default function TripItineraryView({
                               })}
                               
                               {/* 最後のVenueの後に挿入ボタンを表示 */}
-                              {day.itineraries.length > 0 && (
-                                <div className="flex justify-center py-4">
-                                  <div className="relative flex items-center justify-center">
-                                    {/* Gitタイムライン風の縦線（上側のみ） */}
-                                    <div className="absolute left-1/2 transform -translate-x-1/2 w-0.5 h-4 bg-gray-300 top-0"></div>
-                                    
-                                    {/* 挿入ボタン */}
-                                    <button
-                                      onClick={() => onInsertSchedule(day.id, (day.itineraries?.length || 0) - 1)}
-                                      className="w-8 h-8 bg-blue-500 text-white rounded-full flex items-center justify-center hover:bg-blue-600 transition-colors shadow-sm"
-                                      title="最後にVenueを追加"
-                                    >
-                                      <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-                                        <path d="M12 2C13.1 2 14 2.9 14 4V10H20C21.1 10 22 10.9 22 12S21.1 14 20 14H14V20C14 21.1 13.1 22 12 22S10 21.1 10 20V14H4C2.9 14 2 13.1 2 12S2.9 10 4 10H10V4C10 2.9 10.9 2 12 2Z" />
-                                        <path 
-                                          d="M12 2C8.13 2 5 5.13 5 9C5 14.25 12 22 12 22S19 14.25 19 9C19 5.13 15.87 2 12 2ZM12 11.5C10.62 11.5 9.5 10.38 9.5 9S10.62 6.5 12 6.5S14.5 7.62 14.5 9S13.38 11.5 12 11.5Z" 
-                                          fill="white"
-                                          opacity="0.8"
-                                          transform="scale(0.3) translate(20, 20)"
-                                        />
-                                      </svg>
-                                    </button>
+                              {[...day.itineraries].sort((a, b) => a.sort_number - b.sort_number).length > 0 && (() => {
+                                const sortedItineraries = [...day.itineraries].sort((a, b) => a.sort_number - b.sort_number)
+                                const lastItinerary = sortedItineraries[sortedItineraries.length - 1]
+                                return (
+                                  <div className="flex justify-center py-4">
+                                    <div className="relative flex items-center justify-center">
+                                      {/* Gitタイムライン風の縦線（上側のみ） */}
+                                      <div className="absolute left-1/2 transform -translate-x-1/2 w-0.5 h-4 bg-gray-300 top-0"></div>
+                                      
+                                      {/* 挿入ボタン */}
+                                      <button
+                                        onClick={() => onInsertSchedule(day.id, lastItinerary.sort_number)}
+                                        className="w-8 h-8 bg-blue-500 text-white rounded-full flex items-center justify-center hover:bg-blue-600 transition-colors shadow-sm"
+                                        title="最後にVenueを追加"
+                                      >
+                                        <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                                          <path d="M12 2C13.1 2 14 2.9 14 4V10H20C21.1 10 22 10.9 22 12S21.1 14 20 14H14V20C14 21.1 13.1 22 12 22S10 21.1 10 20V14H4C2.9 14 2 13.1 2 12S2.9 10 4 10H10V4C10 2.9 10.9 2 12 2Z" />
+                                          <path 
+                                            d="M12 2C8.13 2 5 5.13 5 9C5 14.25 12 22 12 22S19 14.25 19 9C19 5.13 15.87 2 12 2ZM12 11.5C10.62 11.5 9.5 10.38 9.5 9S10.62 6.5 12 6.5S14.5 7.62 14.5 9S13.38 11.5 12 11.5Z" 
+                                            fill="white"
+                                            opacity="0.8"
+                                            transform="scale(0.3) translate(20, 20)"
+                                          />
+                                        </svg>
+                                      </button>
+                                    </div>
                                   </div>
-                                </div>
-                              )}
+                                )
+                              })()}
                             </div>
                           </SortableContext>
                         </DndContext>


### PR DESCRIPTION
Correct itinerary display order and insertion logic to ensure itineraries are always shown in `sort_number` sequence and maintain continuous numbering upon insertion.

The UI was not sorting itineraries by `sort_number` before rendering, leading to incorrect visual order and indices despite correct data in Firestore. The insertion API's `insertAfterIndex` parameter was also ambiguously handled, causing issues with maintaining continuous `sort_number`s when adding new items. This PR fixes both the display and insertion logic to ensure a consistent 1-based, continuous `sort_number` sequence is maintained and correctly reflected in the UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-172735ef-1168-425f-8f88-335d724d9ab7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-172735ef-1168-425f-8f88-335d724d9ab7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

