### PR TITLE
Fix itinerary display order and sort numbers

### DIFF
--- a/app/[userSlug]/[tripSlug]/page.tsx
+++ b/app/[userSlug]/[tripSlug]/page.tsx
@@ -381,8 +381,8 @@ export default function SlugBasedTripPage() {
   const handleScheduleAdded = async (newItinerary: any) => {
     if (!trip) return
 
-    // 新しいAPIが正しいsort_numberで挿入し、後続のスケジュールを再番号付けするので、
-    // フロントエンド側では単純に新しいスケジュールを配列に追加するだけで十分
+    // サーバー側では挿入位置に応じて後続の sort_number を +1 済みだが、
+    // ローカル状態は古いままなので、同様の再番号付けを適用してから追加する
     setTrip(prevTrip => {
       if (!prevTrip) return prevTrip
       
@@ -391,12 +391,20 @@ export default function SlugBasedTripPage() {
         days: prevTrip.days?.map(day => {
           if (day.id === newItinerary.day_id) {
             const currentItineraries = day.itineraries || []
-            
-            // 新しいスケジュールを正しい位置に挿入
-            // 新しいAPIがsort_numberを正しく設定するので、sort_number順に挿入
-            const sortedItineraries = [...currentItineraries, newItinerary]
+
+            // 後続（newItinerary.sort_number 以上）の既存要素を +1 して重複を解消
+            const updatedExisting = currentItineraries.map(item => {
+              if (item.id === newItinerary.id) return item
+              if ((item.sort_number || 0) >= (newItinerary.sort_number || 0)) {
+                return { ...item, sort_number: (item.sort_number || 0) + 1 }
+              }
+              return item
+            })
+
+            // 新規を統合して sort_number 順に整列
+            const sortedItineraries = [...updatedExisting, newItinerary]
               .sort((a, b) => a.sort_number - b.sort_number)
-            
+
             return {
               ...day,
               itineraries: sortedItineraries

--- a/components/trip/TripItineraryView.tsx
+++ b/components/trip/TripItineraryView.tsx
@@ -186,15 +186,21 @@ export default function TripItineraryView({
                             Venue / Point of Interest を追加
                           </button>
                         </div>
-                        <DndContext collisionDetection={closestCenter} onDragEnd={onDragEnd}>
+                        {(() => {
+                          // 表示・DnDの一貫性担保のため常に sort_number 順で並べ替え
+                          const sortedItineraries = [...(day.itineraries || [])].sort(
+                            (a, b) => a.sort_number - b.sort_number
+                          )
+                          return (
+                            <DndContext collisionDetection={closestCenter} onDragEnd={onDragEnd}>
                           <SortableContext 
-                            items={day.itineraries.map(i => i.id)} 
+                            items={sortedItineraries.map(i => i.id)} 
                             strategy={verticalListSortingStrategy}
                           >
                             <div className="space-y-0">
-                              {day.itineraries.map((itinerary, index) => {
-                                const previousItinerary = index > 0 ? day.itineraries?.[index - 1] : null
-                                const nextItinerary = index < (day.itineraries?.length || 0) - 1 ? day.itineraries?.[index + 1] : null
+                              {sortedItineraries.map((itinerary, index) => {
+                                const previousItinerary = index > 0 ? sortedItineraries?.[index - 1] : null
+                                const nextItinerary = index < (sortedItineraries?.length || 0) - 1 ? sortedItineraries?.[index + 1] : null
                                 
                                 return (
                                   <div key={itinerary.id} className="relative">
@@ -211,7 +217,7 @@ export default function TripItineraryView({
                                       onItineraryClick={onItineraryClick}
                                       isSelected={selectedItineraryId === itinerary.id}
                                       isFirst={index === 0}
-                                      isLast={index === (day.itineraries?.length || 0) - 1}
+                                      isLast={index === (sortedItineraries?.length || 0) - 1}
                                       availableDays={trip.days?.map(d => ({
                                         id: d.id,
                                         day_number: d.day_number,
@@ -233,7 +239,7 @@ export default function TripItineraryView({
                                     )}
                                     
                                     {/* Venue間の挿入ボタン（距離表示がない場合のみ） */}
-                                    {index < (day.itineraries?.length || 0) - 1 && 
+                                    {index < (sortedItineraries?.length || 0) - 1 && 
                                      (!itinerary.place_data || !nextItinerary?.place_data || 
                                       itinerary.place_data.place_id === nextItinerary.place_data.place_id) && (
                                       <VenueInsertButton
@@ -246,7 +252,7 @@ export default function TripItineraryView({
                               })}
                               
                               {/* 最後のVenueの後に挿入ボタンを表示 */}
-                              {day.itineraries.length > 0 && (
+                              {sortedItineraries.length > 0 && (
                                 <div className="flex justify-center py-4">
                                   <div className="relative flex items-center justify-center">
                                     {/* Gitタイムライン風の縦線（上側のみ） */}
@@ -254,7 +260,7 @@ export default function TripItineraryView({
                                     
                                     {/* 挿入ボタン */}
                                     <button
-                                      onClick={() => onInsertSchedule(day.id, (day.itineraries?.length || 0) - 1)}
+                                      onClick={() => onInsertSchedule(day.id, sortedItineraries.length)}
                                       className="w-8 h-8 bg-blue-500 text-white rounded-full flex items-center justify-center hover:bg-blue-600 transition-colors shadow-sm"
                                       title="最後にVenueを追加"
                                     >
@@ -274,6 +280,8 @@ export default function TripItineraryView({
                             </div>
                           </SortableContext>
                         </DndContext>
+                          )
+                        })()}
                       </div>
                     ) : (
                       <div className="text-center py-8 text-gray-500">


### PR DESCRIPTION
Fixes itinerary display order and indexing by synchronizing local state re-indexing with backend logic and ensuring consistent sorting.

The frontend's local state previously failed to re-index `sort_number` for existing itineraries after a new item was inserted, leading to display inconsistencies and duplicate numbers, despite correct backend updates. This PR updates the local state to mirror backend re-indexing, ensures all itinerary displays are consistently sorted by `sort_number`, and corrects an off-by-one error for the "add to end" button's insertion position.

---
<a href="https://cursor.com/background-agent?bcId=bc-ddb19734-56c5-4aa2-ad27-33978ece3967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ddb19734-56c5-4aa2-ad27-33978ece3967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Itineraries are now consistently displayed in the correct order for each day.
  * Adding a new itinerary inserts it at the chosen position and updates surrounding items accordingly.
  * Drag-and-drop interactions use a stable order, improving predictability and preventing misplaced items.
  * UI checks (previous/next, last-item/insert buttons) now reflect the correct list state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->